### PR TITLE
[#] Multiple `present` bug:

### DIFF
--- a/src/SDLHelper.cpp
+++ b/src/SDLHelper.cpp
@@ -183,7 +183,6 @@ void SDLHelper::renderMenu()
     renderText(font, "Play", playButton.x + 70, playButton.y + 10, textColor);
     renderText(font, "Settings", settingsButton.x + 50, settingsButton.y + 10, textColor);
     renderText(font, "Exit", exitButton.x + 70, exitButton.y + 10, textColor);
-    this->present();
 }
 // Update game state
 void SDLHelper::update()


### PR DESCRIPTION
- Remove unnecessary call to `present()` in `renderMenu()` function
-  game update Logic already have the `m_sdl->present()`

Issue: #42