### PR TITLE
[~] Game: Enhance CollisionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # C++ Gravitation Simulation with using SDL2 Library.
 
 ## **Installing dependencies and building the project for the first time**.
-This project created using WSL Ubuntu LTS on a windows platform. But before you clone and use make to build the project, you have to make some configuration if this is the first time using C/GCC/SDL in your machine.
+This project created using WSL Ubuntu 22.04 LTS on a windows platform. But before you clone and use make to build the project, you have to make some configuration if this is the first time using C/GCC/SDL in your machine.
 
 
 ### **Dependencies**

--- a/include/CollisionManager.hpp
+++ b/include/CollisionManager.hpp
@@ -8,12 +8,31 @@
 #include <vector>
 namespace game::engine
 {
+struct pair_hash
+{
+    template<class T1, class T2>
+    std::size_t operator()(const std::pair<T1, T2>& pair) const
+    {
+        auto h1 = std::hash<T1>{}(pair.first);
+        auto h2 = std::hash<T2>{}(pair.second);
+        return h1 ^ (h2 << 1);  // Combine hashes
+    }
+};
+
 class CollisionManager
 {
+
+    using SpatialGrid =
+        std::unordered_map<std::pair<int, int>, std::vector<game::object::GameObject*>, pair_hash>;
+    using CollisionsObject =
+        std::vector<std::pair<game::object::GameObject*, game::object::GameObject*>>;
+
   private:
     std::vector<std::pair<game::object::GameObject*, game::object::GameObject*>>
         m_active_collisions;
     int m_cumulative_collision_count = 0;
+    const std::vector<std::pair<int, int>> neighborOffsets = {
+        {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 0}, {0, 1}, {1, -1}, {1, 0}, {1, 1}};
 
   public:
     CollisionManager() = default;
@@ -24,16 +43,6 @@ class CollisionManager
     const std::vector<std::pair<game::object::GameObject*, game::object::GameObject*>>&
         get_active_collisions() const;
     int get_collision_count() const;
-    struct pair_hash
-    {
-        template<class T1, class T2>
-        std::size_t operator()(const std::pair<T1, T2>& pair) const
-        {
-            auto h1 = std::hash<T1>{}(pair.first);
-            auto h2 = std::hash<T2>{}(pair.second);
-            return h1 ^ (h2 << 1);  // Combine hashes
-        }
-    };
 };
 }  // namespace game::engine
 

--- a/include/CollisionManager.hpp
+++ b/include/CollisionManager.hpp
@@ -6,6 +6,8 @@
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <unordered_map>
+
 namespace game::engine
 {
 struct pair_hash

--- a/include/Game.hpp
+++ b/include/Game.hpp
@@ -37,7 +37,7 @@ class Game
     {
         return m_window_height;
     }
-    GameState* p_gameState;
+    GameState m_gameState;
 
   private:
     void init();

--- a/include/GameObject.hpp
+++ b/include/GameObject.hpp
@@ -3,7 +3,7 @@
 
 #include "ClassLogger.hpp"
 #include "ObjectHelper.hpp"
-
+#include "GameHelper.hpp"
 #include <algorithm>
 #include <cmath>
 #include <memory>
@@ -40,6 +40,7 @@ class GameObject
         m_pos = {0.0f, 0.0f};
         m_acceleration = {0.0f, 0.0f};
         m_restitution = 1;
+        m_is_stable = false;
     };
     virtual ~GameObject() {}
 
@@ -66,12 +67,14 @@ class GameObject
     void setRestitution(double restitution);
     void setColor(Color color);
     void setColorState(ColorState colorState);
+    void setStability(bool stable);
+    bool getStability() const;
     std::vector<Position> getLastPositions() const;
     Force getForce() const;
-    double get_mass();
+    double getMass() const;
 
-    ObjectType get_type() const;
-    Color get_color() const;
+    ObjectType getType() const;
+    Color getColor() const;
     Position getPosition() const;
     Velocity getVelocity() const;
     Acceleration getAcceleration() const;
@@ -86,6 +89,7 @@ class GameObject
     double m_mass;
     double m_restitution;  //  Coefficient of restitution (bounciness) for elastic/inelastic
                            //  collisions. 1.0 for perfectly elastic, 0.0 for perfectly inelastic.
+    bool m_is_stable;
     Force m_force;
     ColorState m_color_state;
     Color m_color;

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,8 +1,10 @@
 #pragma once
+#include <array>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <type_traits>
 namespace utils
 {
 class Logger

--- a/src/CollisionManager.cpp
+++ b/src/CollisionManager.cpp
@@ -6,39 +6,16 @@ namespace game::engine
 void CollisionManager::resolve_collisions(
     const std::vector<std::unique_ptr<game::object::GameObject>>& objects)
 {
-    // Define the grid size
     const float cellSize = 50.0f;  // Adjust based on object size and game world
 
-    // A map to store objects by their grid cell
-    std::unordered_map<std::pair<int, int>, std::vector<game::object::GameObject*>, pair_hash>
-        spatialGrid;
+    SpatialGrid spatialGrid;  // A map to store objects by their grid cell
 
     // Helper lambda to compute grid cell for a position
     auto getCell = [cellSize](const game::object::GameObject& obj)
     {
-        int pos_x, pos_y;
-        switch (obj.get_type())
-        {
-            case game::object::helper::ObjectType::CIRCLE:
-                if (const auto* circle = dynamic_cast<const game::object::CircleObject*>(&obj))
-                {
-                    pos_x = static_cast<int>(std::floor(circle->getPosition().getX() / cellSize));
-                    pos_y = static_cast<int>(std::floor(circle->getPosition().getY() / cellSize));
-                }
-                break;
-            case game::object::helper::ObjectType::RECTANGLE:
-                if (const auto* rect = dynamic_cast<const game::object::RectObject*>(&obj))
-                {
-                    pos_x = static_cast<int>(std::floor(
-                        (rect->getPosition().getX() + rect->get_width() / 2) / cellSize));
-                    pos_y = static_cast<int>(std::floor(
-                        (rect->getPosition().getY() + rect->get_height() / 2) / cellSize));
-                }
-                break;
-        }
-
-        int cellX = static_cast<int>(std::floor(pos_x / cellSize));
-        int cellY = static_cast<int>(std::floor(pos_y / cellSize));
+        game::object::Position center = obj.getCenter();
+        int cellX = static_cast<int>(std::floor(center.getX() / cellSize));
+        int cellY = static_cast<int>(std::floor(center.getY() / cellSize));
         return std::make_pair(cellX, cellY);
     };
 
@@ -50,57 +27,58 @@ void CollisionManager::resolve_collisions(
     }
 
     // Temporary set to track current collisions
-    std::vector<std::pair<game::object::GameObject*, game::object::GameObject*>> currentCollisions;
+    CollisionsObject currentCollisions;
 
     // Check collisions within each cell and neighboring cells
     for (const auto& [cell, cellObjects] : spatialGrid)
     {
-        const int cellX = cell.first;
-        const int cellY = cell.second;
-
-        // Iterate over the cell and its 8 neighbors
-        for (int dx = -1; dx <= 1; ++dx)
+        for (const auto& offset : this->neighborOffsets)
         {
-            for (int dy = -1; dy <= 1; ++dy)
+            auto neighborCell =
+                std::make_pair(cell.first + offset.first, cell.second + offset.second);
+            if (spatialGrid.find(neighborCell) == spatialGrid.end())
             {
-                auto neighborCell = std::make_pair(cellX + dx, cellY + dy);
-                if (spatialGrid.find(neighborCell) == spatialGrid.end())
-                    continue;
+                continue;
+            }
+            const auto& neighborObjects = spatialGrid[neighborCell];
 
-                const auto& neighborObjects = spatialGrid[neighborCell];
-
-                // Check for collisions between objects in the current cell and neighbor cell
-                for (auto* obj1 : cellObjects)
+            // Check for collisions between objects in the current cell and neighbor cell
+            for (auto* obj1 : cellObjects)
+            {
+                for (auto* obj2 : neighborObjects)
                 {
-                    for (auto* obj2 : neighborObjects)
+                    if (obj1 >= obj2)
                     {
-                        if (obj1 == obj2)
-                            continue;  // Skip self-collision
-                        if (obj1->is_colliding_with(*obj2))
-                        {
-                            obj1->on_collision(*obj2);
-                            obj2->on_collision(*obj1);
-                            // Track the colliding pair
-                            currentCollisions.emplace_back(obj1, obj2);
-                            m_cumulative_collision_count++;
-                        }
-                        else
-                        {
-                            m_active_collisions.erase(
-                                std::remove_if(
-                                    m_active_collisions.begin(), m_active_collisions.end(),
-                                    [&](const std::pair<game::object::GameObject*,
-                                                        game::object::GameObject*>& pair)
-                                    {
-                                        return (pair.first == obj1 && pair.second == obj2) ||
-                                               (pair.first == obj2 && pair.second == obj1);
-                                    }),
-                                m_active_collisions.end());
-                        }
+                        continue;  // Skip self-collision and duplicate checks
+                    }
+
+                    if (obj1->is_colliding_with(*obj2))
+                    {
+                        currentCollisions.emplace_back(obj1, obj2);
+                        m_cumulative_collision_count++;
+                    }
+                    else
+                    {
+                        m_active_collisions.erase(
+                            std::remove_if(m_active_collisions.begin(), m_active_collisions.end(),
+                                           [&](const std::pair<game::object::GameObject*,
+                                                               game::object::GameObject*>& pair)
+                                           {
+                                               return (pair.first == obj1 && pair.second == obj2) ||
+                                                      (pair.first == obj2 && pair.second == obj1);
+                                           }),
+                            m_active_collisions.end());
                     }
                 }
             }
         }
+    }
+
+    // Resolve Collisions
+    for (const auto& [obj1, obj2] : currentCollisions)
+    {
+        obj1->on_collision(*obj2);
+        obj2->on_collision(*obj1);
     }
 
     // Update active collisions

--- a/src/CollisionManager.cpp
+++ b/src/CollisionManager.cpp
@@ -126,7 +126,7 @@ void CollisionManager::calculate_gravitational_force(
                 sqrt(d_square(obj2->getPosition().getX() - obj1->getPosition().getX()) +
                      d_square(obj2->getPosition().getY() - obj1->getPosition().getY()));
             double g_force =
-                (GRAVITATIONAL_CONSTANT * obj1->get_mass() * obj2->get_mass()) / d_square(distance);
+                (GRAVITATIONAL_CONSTANT * obj1->getMass() * obj2->getMass()) / d_square(distance);
             game::object::helper::Vector2D force{0, 0};
 
             if (!distance)

--- a/src/CollisionManager.cpp
+++ b/src/CollisionManager.cpp
@@ -54,6 +54,15 @@ void CollisionManager::resolve_collisions(
 
                     if (obj1->is_colliding_with(*obj2))
                     {
+                        if(!obj2->getStability())
+                        {
+                            if(obj2->getVelocity().magnitude()< 2.5)
+                            {
+                                object::helper::Vector2D zeroSpeed{0,0};
+                                obj2->setVelocity(zeroSpeed);
+                                return;
+                            }
+                        }
                         currentCollisions.emplace_back(obj1, obj2);
                         m_cumulative_collision_count++;
                     }

--- a/src/CollisionManager.cpp
+++ b/src/CollisionManager.cpp
@@ -54,6 +54,43 @@ void CollisionManager::resolve_collisions(
 
                     if (obj1->is_colliding_with(*obj2))
                     {
+                        currentCollisions.emplace_back(obj1, obj2);
+                        m_cumulative_collision_count++;
+                    }
+                    else
+                    {
+                        m_active_collisions.erase(
+                            std::remove_if(m_active_collisions.begin(), m_active_collisions.end(),
+                                           [&](const std::pair<game::object::GameObject*,
+                                                               game::object::GameObject*>& pair)
+                                           {
+                                               return (pair.first == obj1 && pair.second == obj2) ||
+                                                      (pair.first == obj2 && pair.second == obj1);
+                                           }),
+                            m_active_collisions.end());
+                    }
+                }
+            }
+        }
+    }
+
+    // Resolve Collisions
+    for (const auto& [obj1, obj2] : currentCollisions)
+    {
+        obj1->on_collision(*obj2);
+        obj2->on_collision(*obj1);
+            // Check for collisions between objects in the current cell and neighbor cell
+            for (auto* obj1 : cellObjects)
+            {
+                for (auto* obj2 : neighborObjects)
+                {
+                    if (obj1 >= obj2)
+                    {
+                        continue;  // Skip self-collision and duplicate checks
+                    }
+
+                    if (obj1->is_colliding_with(*obj2))
+                    {
                         if(!obj2->getStability())
                         {
                             if(obj2->getVelocity().magnitude()< 2.5)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -72,13 +72,13 @@ void Game::run()
     while (m_sdl->isRunning())
     {
         m_sdl->update();  // Update SDL timing
-        m_sdl->handleEvents(*p_gameState);
-        m_sdl->render(gameObjects, *p_gameState);  // Pass game objects to SDLHelper for rendering
+        m_sdl->handleEvents(m_gameState);
+        m_sdl->render(gameObjects, m_gameState);  // Pass game objects to SDLHelper for rendering
         m_sdl->renderCollisionHighlights(m_collisionManager.get_active_collisions());
         // Fixed timestep for game logic
         while (m_sdl->getAccumulator() >= m_LOGIC_TIMESTEP)
         {
-            if (*p_gameState == game::GameState::PLAYING)
+            if (m_gameState == game::GameState::PLAYING)
             {
                 update();
                 m_sdl->renderCollisionScoreboard(
@@ -95,7 +95,7 @@ void Game::run()
 void Game::init()
 {
     gameObjects = std::vector<std::unique_ptr<game::object::GameObject>>();
-    *p_gameState = GameState::MENU;
+    m_gameState = GameState::MENU;
     std::string loggerName = "sdl_logger";
     m_sdl = std::make_unique<game::sdl::SDLHelper>("Game Title", m_window_width, m_window_height,
                                                    loggerName);

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -98,7 +98,14 @@ void GameObject::update_color(float delta_time)
 }
 void GameObject::setVelocity(Velocity velocity)
 {
-    m_velocity = velocity;
+    if(!m_is_stable)
+    {
+        m_velocity = velocity;
+    }
+    else
+    {
+        m_velocity *= 0;
+    }
 }
 void GameObject::setPosition(Position pos)
 {
@@ -130,15 +137,27 @@ void GameObject::setColorState(ColorState colorState)
 {
     m_color_state = colorState;
 }
-double GameObject::get_mass()
+void GameObject::setStability(bool stable)
+{
+    if(stable)
+    {
+        m_velocity *= 0;
+    }
+    m_is_stable = stable;
+}
+bool GameObject::getStability() const
+{
+    return m_is_stable;
+}
+double GameObject::getMass() const
 {
     return m_mass;
 }
-ObjectType GameObject::get_type() const
+ObjectType GameObject::getType() const
 {
     return m_type;
 }
-Color GameObject::get_color() const
+Color GameObject::getColor() const
 {
     return m_color;
 }
@@ -251,15 +270,19 @@ void GameObject::on_collision(GameObject& other)
     auto speed_this = impulse_vector / this->m_mass;
     auto speed_other = impulse_vector / other.m_mass;
     const double velocityQuantizationStep = 0.01;
-
-    this->m_velocity -= game::object::helper::Vector2D(
-        std::round(speed_this.getX() / velocityQuantizationStep) * velocityQuantizationStep,
-        std::round(speed_this.getY() / velocityQuantizationStep) * velocityQuantizationStep);
-
+    if(!getStability())
+    {
+        this->m_velocity -= game::object::helper::Vector2D(
+            std::round(speed_this.getX() / velocityQuantizationStep) * velocityQuantizationStep,
+            std::round(speed_this.getY() / velocityQuantizationStep) * velocityQuantizationStep);
+    }
     // Quantize the velocity of the other object
-    other.m_velocity += game::object::helper::Vector2D(
-        std::round(speed_other.getX() / velocityQuantizationStep) * velocityQuantizationStep,
-        std::round(speed_other.getY() / velocityQuantizationStep) * velocityQuantizationStep);
+    if(!other.getStability())
+    {
+        other.m_velocity += game::object::helper::Vector2D(
+            std::round(speed_other.getX() / velocityQuantizationStep) * velocityQuantizationStep,
+             std::round(speed_other.getY() / velocityQuantizationStep) * velocityQuantizationStep);
+    }
 }
 
 Acceleration GameObject::getAcceleration() const
@@ -308,8 +331,15 @@ void GameObject::update_position(float delta_time)
 {
     auto x_speed = std::clamp(m_velocity.getX(), MIN_VELOCITY, MAX_VELOCITY);
     auto y_speed = std::clamp(m_velocity.getY(), MIN_VELOCITY, MAX_VELOCITY);
-    m_velocity.setX(x_speed);
-    m_velocity.setY(y_speed);
+    if(!getStability())
+    {
+        m_velocity.setX(x_speed);
+        m_velocity.setY(y_speed);
+    }
+    else
+    {
+        m_velocity *= 0;
+    }
     m_pos += m_velocity * delta_time;
 }
 

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -325,6 +325,7 @@ void GameObject::update_acceleration()
 void GameObject::update_velocity(float delta_time)
 {
     m_velocity += m_acceleration * delta_time;
+    m_logger.debug("\nCurrent speed x: {}\nCurrent speed y: {}\nCurrent magnitude:{}", m_velocity.getX(), m_velocity.getY(),m_velocity.magnitude());
 }
 
 void GameObject::update_position(float delta_time)

--- a/src/RectObject.cpp
+++ b/src/RectObject.cpp
@@ -67,7 +67,7 @@ void RectObject::update(float delta_time, int screen_width, int screen_height)
 
 bool RectObject::border_collision(int screen_width, int screen_height)
 {
-
+    #ifdef BORDER_COLLISION
     if (this->m_pos.getX() < 0)
     {
         this->m_pos.setX(0);
@@ -92,6 +92,30 @@ bool RectObject::border_collision(int screen_width, int screen_height)
         this->m_velocity.reverseY();
         return true;
     }
+    #else
+    if (m_pos.getX() + m_width < 0)
+    {
+        m_pos.setX(screen_width);
+        return true;
+    }
+    if (m_pos.getX() - m_width > screen_width)
+    {
+        m_pos.setX(0);
+        return true;
+    }
+
+    if (m_pos.getY() + m_height < 0)
+    {
+        m_pos.setY(screen_height);
+        return true;
+    }
+    if (m_pos.getY() - m_height > screen_height)
+    {
+        m_pos.setY(0);
+        return true;
+    }
+    #endif
+
     return false;
 }
 

--- a/src/SDLHelper.cpp
+++ b/src/SDLHelper.cpp
@@ -348,7 +348,7 @@ void SDLHelper::drawGameObjects(
     {
         game::object::Position pos = obj->getPosition();
 
-        switch (obj->get_type())
+        switch (obj->getType())
         {
             case game::object::helper::ObjectType::CIRCLE:
                 // Safely cast to CircleObject
@@ -357,9 +357,9 @@ void SDLHelper::drawGameObjects(
                     int radius = static_cast<int>(circle->getRadius());
                     drawCircleFill(pos.getX(), pos.getY(), radius,
                                    {
-                                       static_cast<Uint8>(obj->get_color().r),
-                                       static_cast<Uint8>(obj->get_color().g),
-                                       static_cast<Uint8>(obj->get_color().b),
+                                       static_cast<Uint8>(obj->getColor().r),
+                                       static_cast<Uint8>(obj->getColor().g),
+                                       static_cast<Uint8>(obj->getColor().b),
                                        255  // Fully opaque
                                    });
                 }
@@ -371,9 +371,9 @@ void SDLHelper::drawGameObjects(
                 {
                     drawRectangleFill(pos.getX(), pos.getY(), rect->get_width(), rect->get_height(),
                                       {
-                                          static_cast<Uint8>(obj->get_color().r),
-                                          static_cast<Uint8>(obj->get_color().g),
-                                          static_cast<Uint8>(obj->get_color().b),
+                                          static_cast<Uint8>(obj->getColor().r),
+                                          static_cast<Uint8>(obj->getColor().g),
+                                          static_cast<Uint8>(obj->getColor().b),
                                           255  // Fully opaque
                                       });
                 }
@@ -412,11 +412,11 @@ void SDLHelper::renderCollisionHighlights(
         for (auto* obj : {collision.first, collision.second})
         {
 
-            if (obj->get_type() == game::object::ObjectType::CIRCLE)
+            if (obj->getType() == game::object::ObjectType::CIRCLE)
             {
                 drawOutline(*(dynamic_cast<game::object::CircleObject*>(obj)));
             }
-            else if (obj->get_type() == game::object::ObjectType::RECTANGLE)
+            else if (obj->getType() == game::object::ObjectType::RECTANGLE)
             {
                 drawOutline(*(dynamic_cast<game::object::RectObject*>(obj)));
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,45 +22,49 @@ int main(int argc, char* argv[])
     std::string logger2 = "Circle2";
     std::string logger3 = "Circle3";
     std::string logger4 = "Rect1";
-    auto circle1 = std::make_unique<game::object::CircleObject>(5, logger1);
-    auto circle2 = std::make_unique<game::object::CircleObject>(15, logger2);
-    auto circle3 = std::make_unique<game::object::CircleObject>(15, logger3);
-    auto rectan1 = std::make_unique<game::object::RectObject>(logger1);
+    auto circle1 = std::make_unique<game::object::CircleObject>(30, logger1);
+    auto circle2 = std::make_unique<game::object::CircleObject>(10, logger2);
+    // auto circle3 = std::make_unique<game::object::CircleObject>(15, logger3);
+    // auto rectan1 = std::make_unique<game::object::RectObject>(logger1);
     float width = game.getWindowWidth();
     float height = game.getWindowHeight();
-    game::object::Position pos1 = {width / 2 - 250, height / 2};
-    game::object::Position pos2 = {width / 2 + 250, height / 2};
-    game::object::Position pos3 = {width / 2, height / 2 - 200};
-    game::object::Position pos4 = {width / 2 - 300, height / 2 + 70};
+    game::object::Position pos1 = {width / 2 , height / 2};
+    game::object::Position pos2 = {width / 2 - 250, height / 2 - 250};
+    // game::object::Position pos3 = {width / 2, height / 2 - 200};
+    // game::object::Position pos4 = {width / 2 - 300, height / 2 + 70};
 
     circle1->setPosition(pos1);
     circle2->setPosition(pos2);
-    circle3->setPosition(pos3);
-    rectan1->setPosition(pos4);
+    // circle3->setPosition(pos3);
+    // rectan1->setPosition(pos4);
 
-    circle1->setMass(1.0);
-    circle2->setMass(5000.0);
-    circle3->setMass(100.0);
-    rectan1->setMass(50.0);
+    circle1->setMass(450.0);
+    circle2->setMass(15.0);
+    // circle3->setMass(10.0);
+    // rectan1->setMass(50.0);
 
-    circle1->setRestitution(1.0f);
+    circle1->setRestitution(0.5f);
     circle2->setRestitution(1.0f);
-    circle3->setRestitution(1.0f);
-    rectan1->setRestitution(1.0f);
+    // circle3->setRestitution(1.0f);
+    // rectan1->setRestitution(1.0f);
 
     game::object::Velocity vel1 = {0.0f, 0.0f};
-    game::object::Velocity vel2 = {0.0f, 0.0f};
-    game::object::Velocity vel3 = {0.0f, 0.0f};
-    game::object::Velocity vel4 = {0.0f, 0.0f};
+    game::object::Velocity vel2 = {30.0f, 5.0f};
+    // game::object::Velocity vel3 = {25.0f, -20.0f};
+    // game::object::Velocity vel4 = {30.0f, 20.0f};
+
     circle1->setVelocity(vel1);
     circle2->setVelocity(vel2);
-    circle3->setVelocity(vel3);
-    rectan1->setVelocity(vel4);
+
+    circle1->setStability(true);
+    circle2->setStability(false);
+    // circle3->setVelocity(vel3);
+    // rectan1->setVelocity(vel4);
 
     game.addGameObject(std::move(circle1));
     game.addGameObject(std::move(circle2));
-    game.addGameObject(std::move(circle3));
-    game.addGameObject(std::move(rectan1));
+    // game.addGameObject(std::move(circle3));
+    // game.addGameObject(std::move(rectan1));
 
     game.run();
 }


### PR DESCRIPTION
- Seperate detection and resolve session
- Rearrange inline `pair_hash` struct, so it can be reusable
- Create alias for `SpatialGrid` and `CollisionsObject` to reduce complexity
- Remove dynamic casting while calculating the `center` of the game objects, now call the `getCenter()` function handle the casting operation.

**Remark:**
Read the issue #51 